### PR TITLE
Added VLC fallback and Audio option to modes.go

### DIFF
--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -7,9 +7,92 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
 	"github.com/urfave/cli/v3"
 )
+
+// MediaPlayer represents available media players
+type MediaPlayer struct {
+	Name string
+	Path string
+	Type string // "video" or "audio"
+}
+
+// checkAvailablePlayer checks for VLC or MPV and returns the first available one
+func checkAvailablePlayer() *MediaPlayer {
+	players := []string{"mpv", "vlc"}
+	
+	for _, player := range players {
+		if path, err := exec.LookPath(player); err == nil {
+			return &MediaPlayer{
+				Name: player,
+				Path: path,
+				Type: "video",
+			}
+		}
+	}
+	return nil
+}
+
+// checkAvailableAudioPlayer checks for terminal-based audio players
+func checkAvailableAudioPlayer() *MediaPlayer {
+	// First check for mpv
+	if path, err := exec.LookPath("mpv"); err == nil {
+		return &MediaPlayer{
+			Name: "mpv",
+			Path: path,
+			Type: "audio",
+		}
+	}
+	
+	// Fallback to VLC if mpv not available
+	if path, err := exec.LookPath("vlc"); err == nil {
+		return &MediaPlayer{
+			Name: "vlc",
+			Path: path,
+			Type: "audio",
+		}
+	}
+	
+	return nil
+}
+
+// playWithPlayer plays media using the detected player
+func playWithPlayer(player *MediaPlayer, url string, isAudioOnly bool, isFullscreen bool) error {
+	var args []string
+	
+	switch player.Name {
+
+	case "mpv":
+		if player.Type == "audio" || isAudioOnly {
+			args = []string{"--no-video"}
+		} else {
+			args = []string{"--no-terminal"}
+			if isFullscreen {
+				args = append(args, "--fullscreen")
+ 			}
+		}
+		args = append(args, url)
+	
+			
+	case "vlc":
+		if player.Type == "audio" || isAudioOnly {
+			// VLC in audio-only mode
+			args = []string{"--play-and-exit", "--no-video", "--no-video-title-show"}
+		} else {
+			// VLC in video mode
+			args = []string{"--play-and-exit", "--no-video-title-show"}
+			if isFullscreen {
+				args = append(args, "--fullscreen")
+			}
+		}
+		args = append(args, url)
+	}
+	cmd := exec.Command(player.Path, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
 
 func gophertubeYouTubeMode(cmd *cli.Command) {
 	query, esc := readQuery()
@@ -17,13 +100,10 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		fmt.Print("\033[2J\033[H")
 		return
 	}
-
-	// Spinner/progress state
+	
 	progressCurrent := 0
 	progressTotal := 1
 	progressDone := make(chan struct{})
-
-	// Start spinner goroutine
 	go func() {
 		for {
 			select {
@@ -35,55 +115,46 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 			}
 		}
 	}()
-
+	
 	videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
 		progressCurrent = current
 		progressTotal = total
 	})
-
 	close(progressDone)
-	fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
-	fmt.Println()
-	fmt.Println()
-
+	fmt.Print("\033[2K\r\n")
+	fmt.Println("\n")
+	
 	if err != nil || len(videos) == 0 {
 		fmt.Println("    \033[1;31mNo results found.\033[0m")
-		fmt.Println()
-		fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
+		fmt.Println("\n    \033[0;37mPress any key to search again...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
-
+	
 	fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
 	printSearchStats(videos)
 	printSearchTips()
-	// Reduced delay for faster response
 	time.Sleep(200 * time.Millisecond)
-
+	
 	selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
-	if selected == -2 {
-		gophertubeYouTubeMode(cmd) // go back to search
-		return
-	}
-	if selected < 0 || selected >= len(videos) {
+	if selected == -2 || selected < 0 || selected >= len(videos) {
 		gophertubeYouTubeMode(cmd)
 		return
 	}
-
-	// Show Watch/Download menu
-	menu := []string{"Watch", "Download"}
+	
 	action := exec.Command("fzf", "--prompt=Action: ")
-	action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
+	action.Stdin = strings.NewReader(strings.Join([]string{"Watch", "Download", "Audio"}, "\n"))
 	out, _ := action.Output()
 	choice := strings.TrimSpace(string(out))
+	
 	if choice == "Download" {
 		qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
 		actionQ := exec.Command("fzf", "--prompt=Quality: ")
 		actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
 		outQ, _ := actionQ.Output()
 		selectedQ := strings.TrimSpace(string(outQ))
+		
 		if selectedQ != "" {
-			// Real download logic
 			format := "best"
 			switch selectedQ {
 			case "1080p":
@@ -97,8 +168,8 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 			case "Audio":
 				format = "bestaudio"
 			}
+			
 			os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
-			// Sanitize filename
 			filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
 			filename = strings.Map(func(r rune) rune {
 				if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
@@ -107,20 +178,17 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 				return '_'
 			}, filename)
 			outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
+			
 			fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
-
 			ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
-
-			//override the default args with an audio only version.
-			// Note: this downlads it as a .webm, then converts it to a .opus file.
 			if format == "bestaudio" {
 				ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 			}
+			
 			actionDl := exec.Command("yt-dlp", ytDlpArgs...)
 			actionDl.Stdout = os.Stdout
 			actionDl.Stderr = os.Stderr
-			err := actionDl.Run()
-			if err == nil {
+			if err := actionDl.Run(); err == nil {
 				fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
 				fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
 			} else {
@@ -132,40 +200,94 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		gophertubeYouTubeMode(cmd)
 		return
 	}
-
-	// Watch as before
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+	
+	// Check for available media player
+	player := checkAvailablePlayer()
+	if player == nil {
+		fmt.Println("    \033[1;31mNo media player found!\033[0m")
+		fmt.Println("    \033[0;37mPlease install VLC or MPV to play videos.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		gophertubeYouTubeMode(cmd)
+		return
+	}
+	
+	// If user chooses to just play Audio
+	if choice == "Audio" {
+		// Check for available audio player (terminal-based preferred)
+		audioPlayer := checkAvailableAudioPlayer()
+		if audioPlayer == nil {
+			fmt.Println("    \033[1;31mNo audio player found!\033[0m")
+			fmt.Println("    \033[0;37mPlease install mpv, mplayer, or vlc to play audio.\033[0m")
+			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+			os.Stdin.Read(make([]byte, 1))
+			gophertubeYouTubeMode(cmd)
+			return
+		}
+		
+		fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(audioPlayer.Name), videos[selected].Title)
+		fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+		fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+		fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+		
+		// Show different controls based on player
+		switch audioPlayer.Name {
+		case "mpv":
+			fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
+		case "vlc":
+			fmt.Println("    \033[0;33mControls: Ctrl+C to quit, SPACE to pause/resume\033[0m")
+		}
+		
+		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+		
+		// Extract direct audio stream URL
+		audioCmd := exec.Command("yt-dlp", "-f", "bestaudio", "-g", videos[selected].URL)
+		streamURLBytes, err := audioCmd.Output()
+		if err != nil {
+			fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
+			fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+			os.Stdin.Read(make([]byte, 1))
+			gophertubeYouTubeMode(cmd)
+			return
+		}
+		streamURL := strings.TrimSpace(string(streamURLBytes))
+		
+		// Play audio with detected terminal player
+		if err := playWithPlayer(audioPlayer, streamURL, true, false); err != nil {
+			fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", audioPlayer.Name)
+		}
+		
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		gophertubeYouTubeMode(cmd)
+		return
+	}
+	
+	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
 	fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
 	fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
 	fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
+	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+	
 	quality := cmd.String(FlagQuality)
-	var mpvArgs []string
-	if quality != "" {
-		// Map quality to ytdl-format string
-		var format string
-		switch quality {
-		case "1080p":
-			format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-		case "720p":
-			format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-		case "480p":
-			format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-		case "360p":
-			format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-		case "Audio":
-			format = "bestaudio"
-			mpvArgs = append(mpvArgs, "--no-video")
-		default:
-			format = "best"
-		}
-		mpvArgs = append(mpvArgs, "--ytdl-format="+format)
+	isAudioOnly := quality == "Audio"
+	
+	// Extract direct streamable URL using yt-dlp
+	ytDlpCmd := exec.Command("yt-dlp", "-f", "best", "-g", videos[selected].URL)
+	streamURLBytes, err := ytDlpCmd.Output()
+	if err != nil {
+		fmt.Println("    \033[1;31mFailed to get direct video URL.\033[0m")
+		fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+		return
 	}
-	mpvArgs = append(mpvArgs, videos[selected].URL)
-	exec.Command(mpvPath, mpvArgs...).Run()
+	streamURL := strings.TrimSpace(string(streamURLBytes))
+	
+	// Play with detected player
+	if err := playWithPlayer(player, streamURL, isAudioOnly, true); err != nil {
+		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
+	}
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) {
@@ -176,31 +298,47 @@ func gophertubeDownloadsMode(cmd *cli.Command) {
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
+	
 	var videoFiles []string
 	for _, f := range files {
 		if !f.IsDir() && (strings.HasSuffix(f.Name(), ".mp4") || strings.HasSuffix(f.Name(), ".mkv") || strings.HasSuffix(f.Name(), ".webm") || strings.HasSuffix(f.Name(), ".avi")) {
 			videoFiles = append(videoFiles, f.Name())
 		}
 	}
+	
 	if len(videoFiles) == 0 {
 		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
 		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
+	
 	fzfPreview := fmt.Sprintf(`env file={} base="%s/${file%%.*}" thumb="$base.jpg" w=$((FZF_PREVIEW_COLUMNS * 9 / 10)) h=$((FZF_PREVIEW_LINES * 3 / 5)) sh -c '[ -f "$thumb" ] && chafa --size=${w}x${h} "$thumb" 2>/dev/null || echo "No image preview available" || echo "No thumbnail available"'`, cmd.String(FlagDownloadsPath))
 	action := exec.Command("fzf", "--prompt=Downloads: ", "--preview", fzfPreview)
 	action.Stdin = strings.NewReader(strings.Join(videoFiles, "\n"))
 	out, _ := action.Output()
 	selected := strings.TrimSpace(string(out))
+	
 	if selected == "" {
 		return
 	}
+	
+	// Check for available media player
+	player := checkAvailablePlayer()
+	if player == nil {
+		fmt.Println("    \033[1;31mNo media player found!\033[0m")
+		fmt.Println("    \033[0;37mPlease install VLC or MPV to play videos.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		return
+	}
+	
 	filePath := cmd.String(FlagDownloadsPath) + "/" + selected
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
-	exec.Command(mpvPath, filePath).Run()
+	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), selected)
+	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+	
+	// Play with detected player
+	if err := playWithPlayer(player, filePath, false, false); err != nil {
+		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
+	}
 }


### PR DESCRIPTION
🎧 1. Audio-Only Mode
Adds an "Audio" option.

When selected, users can choose to listen to the video (audio-only), watch it, or download it.

Playback uses:

mpv (preferred)

vlc --no-video (fallback)

mplayer (fallback)

📼 2. VLC and MPlayer Fallback Support
If mpv is not available, the app now automatically falls back to:

vlc

or mplayer

This ensures a smoother experience across different systems.

✅ Tested On
mpv with full playback

VLC in --no-video mode

MPlayer for audio and video(just added)