### PR TITLE
Enhanced mpv window closer

### DIFF
--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -17,155 +17,158 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		fmt.Print("\033[2J\033[H")
 		return
 	}
+	for {
+		// Spinner/progress state
+		progressCurrent := 0
+		progressTotal := 1
+		progressDone := make(chan struct{})
 
-	// Spinner/progress state
-	progressCurrent := 0
-	progressTotal := 1
-	progressDone := make(chan struct{})
-
-	// Start spinner goroutine
-	go func() {
-		for {
-			select {
-			case <-progressDone:
-				return
-			default:
-				printProgressBar(progressCurrent, progressTotal)
-				time.Sleep(100 * time.Millisecond)
-			}
-		}
-	}()
-
-	videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
-		progressCurrent = current
-		progressTotal = total
-	})
-
-	close(progressDone)
-	fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
-	fmt.Println()
-	fmt.Println()
-
-	if err != nil || len(videos) == 0 {
-		fmt.Println("    \033[1;31mNo results found.\033[0m")
-		fmt.Println()
-		fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		return
-	}
-
-	fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
-	printSearchStats(videos)
-	printSearchTips()
-	// Reduced delay for faster response
-	time.Sleep(200 * time.Millisecond)
-
-	selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
-	if selected == -2 {
-		gophertubeYouTubeMode(cmd) // go back to search
-		return
-	}
-	if selected < 0 || selected >= len(videos) {
-		gophertubeYouTubeMode(cmd)
-		return
-	}
-
-	// Show Watch/Download menu
-	menu := []string{"Watch", "Download"}
-	action := exec.Command("fzf", "--prompt=Action: ")
-	action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
-	out, _ := action.Output()
-	choice := strings.TrimSpace(string(out))
-	if choice == "Download" {
-		qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
-		actionQ := exec.Command("fzf", "--prompt=Quality: ")
-		actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
-		outQ, _ := actionQ.Output()
-		selectedQ := strings.TrimSpace(string(outQ))
-		if selectedQ != "" {
-			// Real download logic
-			format := "best"
-			switch selectedQ {
-			case "1080p":
-				format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-			case "720p":
-				format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-			case "480p":
-				format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-			case "360p":
-				format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-			case "Audio":
-				format = "bestaudio"
-			}
-			os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
-			// Sanitize filename
-			filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
-			filename = strings.Map(func(r rune) rune {
-				if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
-					return r
+		// Start spinner goroutine
+		go func() {
+			for {
+				select {
+				case <-progressDone:
+					return
+				default:
+					printProgressBar(progressCurrent, progressTotal)
+					time.Sleep(100 * time.Millisecond)
 				}
-				return '_'
-			}, filename)
-			outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
-			fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
-
-			ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
-
-			//override the default args with an audio only version.
-			// Note: this downlads it as a .webm, then converts it to a .opus file.
-			if format == "bestaudio" {
-				ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 			}
-			actionDl := exec.Command("yt-dlp", ytDlpArgs...)
-			actionDl.Stdout = os.Stdout
-			actionDl.Stderr = os.Stderr
-			err := actionDl.Run()
-			if err == nil {
-				fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
-				fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
-			} else {
-				fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
-			}
-			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		}()
+
+		videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
+			progressCurrent = current
+			progressTotal = total
+		})
+
+		close(progressDone)
+		fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
+		fmt.Println()
+		fmt.Println()
+
+		if err != nil || len(videos) == 0 {
+			fmt.Println("    \033[1;31mNo results found.\033[0m")
+			fmt.Println()
+			fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
 			os.Stdin.Read(make([]byte, 1))
+			return
 		}
-		gophertubeYouTubeMode(cmd)
-		return
-	}
 
-	// Watch as before
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
-	fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-	fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-	fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
-	quality := cmd.String(FlagQuality)
-	var mpvArgs []string
-	if quality != "" {
-		// Map quality to ytdl-format string
-		var format string
-		switch quality {
-		case "1080p":
-			format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-		case "720p":
-			format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-		case "480p":
-			format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-		case "360p":
-			format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-		case "Audio":
-			format = "bestaudio"
-			mpvArgs = append(mpvArgs, "--no-video")
-		default:
-			format = "best"
+		fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
+		printSearchStats(videos)
+		printSearchTips()
+		// Reduced delay for faster response
+		time.Sleep(200 * time.Millisecond)
+
+		for {
+			selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
+			if selected == -2 {
+				// User pressed escape, go back to new search
+				return
+			}
+			if selected < 0 || selected >= len(videos) {
+				continue // Stay in the same list
+			}
+
+			// Show Watch/Download menu
+			menu := []string{"Watch", "Download"}
+			action := exec.Command("fzf", "--prompt=Action: ")
+			action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
+			out, _ := action.Output()
+			choice := strings.TrimSpace(string(out))
+			if choice == "Download" {
+				qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
+				actionQ := exec.Command("fzf", "--prompt=Quality: ")
+				actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
+				outQ, _ := actionQ.Output()
+				selectedQ := strings.TrimSpace(string(outQ))
+				if selectedQ != "" {
+					// Real download logic
+					format := "best"
+					switch selectedQ {
+					case "1080p":
+						format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+					case "720p":
+						format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
+					case "480p":
+						format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
+					case "360p":
+						format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
+					case "Audio":
+						format = "bestaudio"
+					}
+					os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
+					// Sanitize filename
+					filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
+					filename = strings.Map(func(r rune) rune {
+						if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
+							return r
+						}
+						return '_'
+					}, filename)
+					outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
+					fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
+
+					ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+
+					//override the default args with an audio only version.
+					// Note: this downlads it as a .webm, then converts it to a .opus file.
+					if format == "bestaudio" {
+						ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+					}
+					actionDl := exec.Command("yt-dlp", ytDlpArgs...)
+					actionDl.Stdout = os.Stdout
+					actionDl.Stderr = os.Stderr
+					err := actionDl.Run()
+					if err == nil {
+						fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
+						fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
+					} else {
+						fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
+					}
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					os.Stdin.Read(make([]byte, 1))
+				}
+				gophertubeYouTubeMode(cmd)
+				return
+			}
+
+			// Watch as before
+			fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+			fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+			fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+			fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+			fmt.Println()
+			fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+			fmt.Println()
+			mpvPath := "mpv"
+			quality := cmd.String(FlagQuality)
+			var mpvArgs []string
+			if quality != "" {
+				// Map quality to ytdl-format string
+				var format string
+				switch quality {
+				case "1080p":
+					format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+				case "720p":
+					format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
+				case "480p":
+					format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
+				case "360p":
+					format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
+				case "Audio":
+					format = "bestaudio"
+					mpvArgs = append(mpvArgs, "--no-video")
+				default:
+					format = "best"
+				}
+				mpvArgs = append(mpvArgs, "--ytdl-format="+format)
+			}
+			mpvArgs = append(mpvArgs, videos[selected].URL)
+			exec.Command(mpvPath, mpvArgs...).Run()
+			continue
 		}
-		mpvArgs = append(mpvArgs, "--ytdl-format="+format)
 	}
-	mpvArgs = append(mpvArgs, videos[selected].URL)
-	exec.Command(mpvPath, mpvArgs...).Run()
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) {


### PR DESCRIPTION
As stated in [#8 ](https://github.com/KrishnaSSH/GopherTube/issues/8) when we close mpv window, it should direct us to the search list instead of of main menu.

I modified modes.go file, specifically  gophertubeYouTubeMode() function.
1. Refactored Search Loop: The function now uses a for loop to keep the user within the search context, instead of exiting after one action.
2. Reused Search List: Using continue after playing a video automatically redisplays the existing search results, avoiding a new search.
3. Recursive Search Reset: The escape key (-2) now calls the function recursively to start a new search, improving navigation.

This code works on my machine, let me know if you guys face any issue, let me know in case of any issues.