### PR TITLE
Make install.sh more flexible

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-print_status() { echo -e "${GREEN}[INFO]${NC} $1"; }
-print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+print_status() { echo -e "${GREEN}[INFO]${NC} $*"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 missing_deps=()
 supported_installers=(apt-get pacman dnf yum zypper brew pkg apk)
 

--- a/install.sh
+++ b/install.sh
@@ -110,5 +110,10 @@ build_install() {
     print_status "GopherTube installed successfully!"
 }
 
-install_deps
+### BEGIN COMMAND EXECUTION
+installer="$(identify_installer)"
+identify_missing_dependencies "${installer}"
+if [[ ${#missing_deps} -gt 0 ]]; then
+  install_deps "${installer}"
+fi
 build_install

--- a/install.sh
+++ b/install.sh
@@ -90,22 +90,59 @@ install_deps() {
     esac
 }
 
-# Build and install
-build_install() {
+# Build gophertube program
+build_gt() {
+    if ! command_exists gophertube && [[ "${FORCE_BUILD:0}" -ne 1 ]]; then
+        print_status "'gophertube' is already installed. Skipping build and installation."
+        print_status "To force installation, set 'FORCE_BUILD' environment vairable to '1' and re-run install script."
+        return 1
+    fi
     print_status "Building GopherTube..."
 
-    [ ! -d "GopherTube" ] && git clone --depth=1 https://github.com/KrishnaSSH/GopherTube.git
-    cd GopherTube
+    repo_needs_cloning=0
+    # Are we in the repo?
+    git_top_dir="$(git rev-parse --show-toplevel)"
+    rev_parse_return_code=$?
+    if [[ "${rev_parse_return_code}" -ne 0 ]]; then
+        >&2 echo "Not currently in a git repository"
+        repo_needs_cloning=1
+    elif [[ "${PWD}" != "${git_top_dir}" ]]; then
+        >&2 echo "Not in top level of git repository. Changing directory"
+        cd "${git_top_dir}"
+    else
+        >&2 echo "In top level of git directory"
+    fi
+    # Is this the right repo?
+    if [[  -f "go.mod" && "$(head -1 go.mod)" == "module gophertube" ]]; then
+        >&2 echo "Did not find 'go.mod' file for gophertube."
+        repo_needs_cloning=1
+    fi
+    if [[ "${repo_needs_cloning}" -eq 1 ]]; then
+        if [[ -d "GopherTube" ]]; then
+            cd GopherTube
+            git pull https://github.com/KrishnaSSH/GopherTube.git
+        else
+            git clone --depth=1 https://github.com/KrishnaSSH/GopherTube.git
+            cd GopherTube
+        fi
+    fi
 
     go mod download
-    go build -o gophertube .
+    go build -o gophertube . && return 0
+    return 1
+}
 
-    sudo cp gophertube /usr/local/bin/
-    sudo mkdir -p /usr/local/share/man/man1
-    sudo cp man/gophertube.1 /usr/local/share/man/man1/ 2>/dev/null || true
+# Install gophertube and man page under "${PREFIX}"
+install_gt() {
+    PREFIX="${PREFIX:-/usr/local}"
+    print_status "Installing files under '${PREFIX}'"
+    [[ 1 -gt 0 ]] && return
+    sudo cp gophertube "${PREFIX}"/bin/
+    sudo mkdir -p "${PREFIX}"/share/man/man1
+    sudo cp man/gophertube.1 "${PREFIX}"/share/man/man1/ 2>/dev/null || true
 
-    mkdir -p ~/.config/gophertube
-    cp config/gophertube.toml ~/.config/gophertube/ 2>/dev/null || true
+    [[ ! -d "${HOME}"/.config/gophertube ]] && mkdir -p "${HOME}"/.config/gophertube
+    [[ ! -f "${HOME}"/.config/gophertube ]] && cp config/gophertube.toml "${HOME}"/.config/gophertube/ 2>/dev/null
 
     print_status "GopherTube installed successfully!"
 }
@@ -116,4 +153,4 @@ identify_missing_dependencies "${installer}"
 if [[ ${#missing_deps} -gt 0 ]]; then
   install_deps "${installer}"
 fi
-build_install
+build_gt && install_gt

--- a/install.sh
+++ b/install.sh
@@ -9,56 +9,106 @@ NC='\033[0m'
 
 print_status() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+missing_deps=()
+supported_installers=(apt-get pacman dnf yum zypper brew pkg apk)
+
+# Utility function to identify if a command exists.
+command_exists() {
+    if command -v "${1}" >/dev/null; then
+        return 1
+    fi
+    return 0
+}
+
+# Determine which (if any) dependencies are missing so they can
+# be selectively installed.
+identify_missing_dependencies() {
+    _installer="${1}"
+    dependencies=(go mpv fzf chafa yt-dlp)
+    case "${_installer}" in
+        "apt-get"|"zypper"|"dnf"|"yum")
+            dependencies+=("python3-pip")
+            #break
+            ;;
+        "pkg")
+            dependencies[${#dependencies[@]-1}]="py39-yt-dlp"
+            #break
+            ;;
+        "apk")
+            dependencies[${#dependencies[@]-1}]="py3-yt-dlp"
+            #break
+            ;;
+    esac
+    for d in "${dependencies[@]}"; do
+        if command_exists "${d}"; then
+            missing_deps+=("${d}")
+        fi
+    done
+}
+
+# Which installer should be used? Used for installing and resolving
+# some package names
+identify_installer() {
+    for si in "${supported_installers[@]}"; do
+        command -v "${si}" >/dev/null && { echo "${si}"; return; }
+    done
+}
 
 # Install dependencies
 install_deps() {
-    print_status "Installing dependencies..."
-    
-    if command -v apt-get >/dev/null; then
-        sudo apt-get update && sudo apt-get install -y go mpv fzf chafa python3-pip
-        pip3 install -U yt-dlp
-    elif command -v pacman >/dev/null; then
-        sudo pacman -S --noconfirm go mpv fzf chafa yt-dlp
-    elif command -v dnf >/dev/null; then
-        sudo dnf install -y go mpv fzf chafa python3-pip
-        pip3 install -U yt-dlp
-    elif command -v yum >/dev/null; then
-        sudo yum install -y go mpv fzf chafa python3-pip
-        pip3 install -U yt-dlp
-    elif command -v zypper >/dev/null; then
-        sudo zypper install -y go mpv fzf chafa python3-pip
-        pip3 install -U yt-dlp
-    elif command -v brew >/dev/null; then
-        brew install go mpv fzf chafa yt-dlp
-    elif command -v pkg >/dev/null; then
-        sudo pkg install -y go mpv fzf chafa py39-yt-dlp
-    elif command -v apk >/dev/null; then
-        sudo apk add go mpv fzf chafa py3-yt-dlp
-    else
-        print_error "Unsupported package manager. Please perform manual installation."
-        exit 1
-    fi
+    installer="${1}"
+    print_status "Installing missing dependencies..."
+    case "${1}" in
+        "apt-get")
+            sudo "${installer}" update
+            ;;
+        "zypper"|"dnf"|"yum")
+            sudo "${installer}" install -y "${missing_deps[@]}"
+            pip3 install -U yt-dlp
+            return
+            ;;
+        "pacman")
+            sudo "${installer}" -S --noconfirm "${missing_deps[@]}"
+            return
+            ;;
+        "brew")
+            "${installer}" install "${missing_deps[@]}"
+            return
+            ;;
+        "pkg")
+            sudo "${installer}" install -y "${missing_deps[@]}"
+            return
+            ;;
+        "apk")
+            sudo "${installer}" add "${missing_deps[@]}"
+            return
+            ;;
+        *)
+            print_error "Unsupported package manager. Please perform manual installation."
+            exit 1
+            ;;
+    esac
 }
 
 # Build and install
 build_install() {
     print_status "Building GopherTube..."
-    
+
     [ ! -d "GopherTube" ] && git clone --depth=1 https://github.com/KrishnaSSH/GopherTube.git
     cd GopherTube
-    
+
     go mod download
     go build -o gophertube .
-    
+
     sudo cp gophertube /usr/local/bin/
     sudo mkdir -p /usr/local/share/man/man1
     sudo cp man/gophertube.1 /usr/local/share/man/man1/ 2>/dev/null || true
-    
+
     mkdir -p ~/.config/gophertube
     cp config/gophertube.toml ~/.config/gophertube/ 2>/dev/null || true
-    
+
     print_status "GopherTube installed successfully!"
 }
 
 install_deps
-build_install 
+build_install


### PR DESCRIPTION
Updates install script to only install dependencies that are missing (addressing #13). In addition, there are additional checks around building to prevent redundant downloads of the repository and/or failures on mac systems with repeat builds/installations (addressing #14).

There are also minor enhancements to allow installation in a separate directory (using the `PREFIX` environment variable), updating the `print_status` and `print_error` functions so they don't require quoting of arguments, etc.

__CAVEAT:__ Testing was primarily done on a mac system. Minimal additional testing was performed on a RHEL 8.x system. I do not have the additional hardware/VMs available to test on the alternate systems.