### PR TITLE
Feature/added audio option

### DIFF
--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -82,14 +82,14 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		fmt.Println()
 
 		if err != nil || len(videos) == 0 {
-			fmt.Println("    \033[1;31mNo results found.\033[0m")
+			fmt.Println("    \033[1;31mNo results found.\033[0m")
 			fmt.Println()
-			fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
+			fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
 			os.Stdin.Read(make([]byte, 1))
 			return
 		}
 
-		fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
+		fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
 		printSearchStats(videos)
 		printSearchTips()
 		// Reduced delay for faster response
@@ -143,7 +143,7 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 						return '_'
 					}, filename)
 					outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
-					fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
+					fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
 
 					ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 
@@ -157,12 +157,12 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 					actionDl.Stderr = os.Stderr
 					err := actionDl.Run()
 					if err == nil {
-						fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
-						fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
+						fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
+						fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
 					} else {
-						fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
+						fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
 					}
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
 					os.Stdin.Read(make([]byte, 1))
 				}
 				gophertubeYouTubeMode(cmd)
@@ -173,50 +173,50 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 			if choice == "Audio" {
 				player := checkAvailablePlayer()
 				if player == nil {
-					fmt.Println("    \033[1;31mNo media player found!\033[0m")
-					fmt.Println("    \033[0;37mPlease install MPV to play audio.\033[0m")
-					fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					fmt.Println("    \033[1;31mNo media player found!\033[0m")
+					fmt.Println("    \033[0;37mPlease install MPV to play audio.\033[0m")
+					fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
 					os.Stdin.Read(make([]byte, 1))
 					continue // Go back to the search results
 				}
 
-				fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
-				fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-				fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-				fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-				fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
-				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+				fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
+				fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+				fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+				fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+				fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
+				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
 
 				// Extract direct audio stream URL
 				audioCmd := exec.Command("yt-dlp", "-f", "bestaudio[ext=m4a]/bestaudio", "-g", videos[selected].URL)
 				streamURLBytes, err := audioCmd.Output()
 				if err != nil {
-					fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
-					fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
+					fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
 					os.Stdin.Read(make([]byte, 1))
 					continue // Go back to the search results
 				}
 				streamURL := strings.TrimSpace(string(streamURLBytes))
 
 				if err := playWithPlayer(player, streamURL, true); err != nil {
-					fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", player.Name)
+					fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", player.Name)
 				}
 
-				fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
+				fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
 				os.Stdin.Read(make([]byte, 1))
 				continue // Return to the search results
 			}
 
 			// Watch as before
-			fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
-			fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-			fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-			fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+			fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+			fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+			fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+			fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
 			fmt.Println()
-			fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+			fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
 			fmt.Println()
 			mpvPath := "mpv"
 			quality := cmd.String(FlagQuality)
@@ -254,8 +254,8 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 func gophertubeDownloadsMode(cmd *cli.Command) {
 	files, err := os.ReadDir(cmd.String(FlagDownloadsPath))
 	if err != nil || len(files) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
@@ -266,8 +266,8 @@ func gophertubeDownloadsMode(cmd *cli.Command) {
 		}
 	}
 	if len(videoFiles) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
@@ -280,9 +280,9 @@ func gophertubeDownloadsMode(cmd *cli.Command) {
 		return
 	}
 	filePath := cmd.String(FlagDownloadsPath) + "/" + selected
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
+	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
 	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
 	fmt.Println()
 	mpvPath := "mpv"
 	exec.Command(mpvPath, filePath).Run()

--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
 	"github.com/urfave/cli/v3"
 )
 
@@ -14,115 +15,37 @@ import (
 type MediaPlayer struct {
 	Name string
 	Path string
-	Type string // "video" or "audio"
 }
 
-// checkAvailablePlayer checks for MPV first, then VLC as fallback
+// checkAvailablePlayer checks for MPV.
 func checkAvailablePlayer() *MediaPlayer {
 	// Prefer MPV for better performance and terminal integration
 	if path, err := exec.LookPath("mpv"); err == nil {
 		return &MediaPlayer{
 			Name: "mpv",
 			Path: path,
-			Type: "video",
 		}
 	}
-	
-	// Fallback to VLC if MPV not available
-	if path, err := exec.LookPath("vlc"); err == nil {
-		return &MediaPlayer{
-			Name: "vlc",
-			Path: path,
-			Type: "video",
-		}
-	}
-	
 	return nil
 }
 
-// checkAvailableAudioPlayer checks for MPV first for audio playback
-func checkAvailableAudioPlayer() *MediaPlayer {
-	// Prefer MPV for audio - excellent terminal integration and performance
-	if path, err := exec.LookPath("mpv"); err == nil {
-		return &MediaPlayer{
-			Name: "mpv",
-			Path: path,
-			Type: "audio",
-		}
-	}
-	
-	// Fallback to VLC if MPV not available
-	if path, err := exec.LookPath("vlc"); err == nil {
-		return &MediaPlayer{
-			Name: "vlc",
-			Path: path,
-			Type: "audio",
-		}
-	}
-	
-	return nil
-}
-
-// playWithPlayer plays media using the detected player
+// playWithPlayer plays media using the detected player.
 func playWithPlayer(player *MediaPlayer, url string, isAudioOnly bool) error {
 	var args []string
 	
-	switch player.Name {
-	case "mpv":
-		if player.Type == "audio" || isAudioOnly {
-			args = []string{
-				"--no-video",
-				
-			}
-		} else {
-			args = []string{
-				"--no-terminal",
-				"--hwdec=auto", // Enable hardware decoding
-				"--vo=gpu",     // Use GPU video output
-				"--quiet",      // Reduce messages but keep controls
-			}
-		}
-		args = append(args, url)
-	
-	case "vlc":
-		if player.Type == "audio" || isAudioOnly {
-			// VLC in audio-only mode with interface suppression
-			args = []string{
-				"--intf", "dummy",           // Use dummy interface (no GUI)
-				"--play-and-exit",
-				"--no-video",
-				"--no-video-title-show",
-				"--quiet",                   // Reduce verbosity
-				"--no-sout-video",          // Disable video output
-			}
-		} else {
-			// VLC in video mode with better error handling
-			args = []string{
-				"--play-and-exit",
-				"--no-video-title-show",
-				"--quiet",                   // Reduce error messages
-				"--avcodec-hw=any",         // Enable hardware decoding
-				"--no-audio-time-stretch",  // Prevent audio sync issues
-				"--clock-jitter=0",         // Reduce timing issues
-				"--network-caching=1000",   // Increase network buffer
-				"--file-caching=1000",      // Increase file buffer
-			}
-		}
-		args = append(args, url)
+	if isAudioOnly {
+		args = []string{"--no-video"}
 	}
 	
+	args = append(args, url)
+	
 	cmd := exec.Command(player.Path, args...)
-	if player.Name == "vlc" {
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-} else {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-}
-
 	
 	return cmd.Run()
 }
+
 
 func gophertubeYouTubeMode(cmd *cli.Command) {
 	query, esc := readQuery()
@@ -130,255 +53,235 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		fmt.Print("\033[2J\033[H")
 		return
 	}
-	
-	progressCurrent := 0
-	progressTotal := 1
-	progressDone := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-progressDone:
-				return
-			default:
-				printProgressBar(progressCurrent, progressTotal)
-				time.Sleep(100 * time.Millisecond)
-			}
-		}
-	}()
-	
-	videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
-		progressCurrent = current
-		progressTotal = total
-	})
-	close(progressDone)
-	fmt.Print("\033[2K\r\n")
-	fmt.Println("\n")
-	
-	if err != nil || len(videos) == 0 {
-		fmt.Println("    \033[1;31mNo results found.\033[0m")
-		fmt.Println("\n    \033[0;37mPress any key to search again...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		return
-	}
-	
-	fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
-	printSearchStats(videos)
-	printSearchTips()
-	time.Sleep(200 * time.Millisecond)
-	
-	selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
-	if selected == -2 || selected < 0 || selected >= len(videos) {
-		gophertubeYouTubeMode(cmd)
-		return
-	}
-	
-	action := exec.Command("fzf", "--prompt=Action: ")
-	action.Stdin = strings.NewReader(strings.Join([]string{"Watch", "Download", "Audio"}, "\n"))
-	out, _ := action.Output()
-	choice := strings.TrimSpace(string(out))
-	
-	if choice == "Download" {
-		qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
-		actionQ := exec.Command("fzf", "--prompt=Quality: ")
-		actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
-		outQ, _ := actionQ.Output()
-		selectedQ := strings.TrimSpace(string(outQ))
-		
-		if selectedQ != "" {
-			format := "best"
-			switch selectedQ {
-			case "1080p":
-				format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-			case "720p":
-				format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-			case "480p":
-				format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-			case "360p":
-				format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-			case "Audio":
-				format = "bestaudio"
-			}
-			
-			os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
-			filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
-			filename = strings.Map(func(r rune) rune {
-				if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
-					return r
+	for {
+		// Spinner/progress state
+		progressCurrent := 0
+		progressTotal := 1
+		progressDone := make(chan struct{})
+
+		// Start spinner goroutine
+		go func() {
+			for {
+				select {
+				case <-progressDone:
+					return
+				default:
+					printProgressBar(progressCurrent, progressTotal)
+					time.Sleep(100 * time.Millisecond)
 				}
-				return '_'
-			}, filename)
-			outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
-			
-			fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
-			ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
-			if format == "bestaudio" {
-				ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 			}
-			
-			actionDl := exec.Command("yt-dlp", ytDlpArgs...)
-			actionDl.Stdout = os.Stdout
-			actionDl.Stderr = os.Stderr
-			if err := actionDl.Run(); err == nil {
-				fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
-				fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
-			} else {
-				fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
-			}
-			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		}()
+
+		videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
+			progressCurrent = current
+			progressTotal = total
+		})
+
+		close(progressDone)
+		fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
+		fmt.Println()
+		fmt.Println()
+
+		if err != nil || len(videos) == 0 {
+			fmt.Println("    \033[1;31mNo results found.\033[0m")
+			fmt.Println()
+			fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
 			os.Stdin.Read(make([]byte, 1))
-		}
-		gophertubeYouTubeMode(cmd)
-		return
-	}
-	
-	// Check for available media player
-	player := checkAvailablePlayer()
-	if player == nil {
-		fmt.Println("    \033[1;31mNo media player found!\033[0m")
-		fmt.Println("    \033[0;37mPlease install MPV (recommended) or VLC to play videos.\033[0m")
-		fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		gophertubeYouTubeMode(cmd)
-		return
-	}
-	
-	// If user chooses to just play Audio
-	if choice == "Audio" {
-		// Check for available audio player (terminal-based preferred)
-		audioPlayer := checkAvailableAudioPlayer()
-		if audioPlayer == nil {
-			fmt.Println("    \033[1;31mNo audio player found!\033[0m")
-			fmt.Println("    \033[0;37mPlease install MPV (recommended) or VLC to play audio.\033[0m")
-			fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
-			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-			os.Stdin.Read(make([]byte, 1))
-			gophertubeYouTubeMode(cmd)
 			return
 		}
-		
-		fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(audioPlayer.Name), videos[selected].Title)
-		fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-		fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-		fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-		
-		// Show different controls based on player
-		switch audioPlayer.Name {
-		case "mpv":
-			fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
-		case "vlc":
-			fmt.Println("    \033[0;33mControls: Ctrl+C to quit (VLC has limited terminal controls)\033[0m")
+
+		fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
+		printSearchStats(videos)
+		printSearchTips()
+		// Reduced delay for faster response
+		time.Sleep(200 * time.Millisecond)
+
+		for {
+			selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
+			if selected == -2 {
+				// User pressed escape, go back to new search
+				return
+			}
+			if selected < 0 || selected >= len(videos) {
+				continue // Stay in the same list
+			}
+
+			// Show Watch/Download/Audio menu
+			menu := []string{"Watch", "Download", "Audio"}
+			action := exec.Command("fzf", "--prompt=Action: ")
+			action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
+			out, _ := action.Output()
+			choice := strings.TrimSpace(string(out))
+			
+			if choice == "Download" {
+				qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
+				actionQ := exec.Command("fzf", "--prompt=Quality: ")
+				actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
+				outQ, _ := actionQ.Output()
+				selectedQ := strings.TrimSpace(string(outQ))
+				if selectedQ != "" {
+					// Real download logic
+					format := "best"
+					switch selectedQ {
+					case "1080p":
+						format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+					case "720p":
+						format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
+					case "480p":
+						format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
+					case "360p":
+						format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
+					case "Audio":
+						format = "bestaudio"
+					}
+					os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
+					// Sanitize filename
+					filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
+					filename = strings.Map(func(r rune) rune {
+						if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
+							return r
+						}
+						return '_'
+					}, filename)
+					outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
+					fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
+
+					ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+
+					//override the default args with an audio only version.
+					// Note: this downlads it as a .webm, then converts it to a .opus file.
+					if format == "bestaudio" {
+						ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+					}
+					actionDl := exec.Command("yt-dlp", ytDlpArgs...)
+					actionDl.Stdout = os.Stdout
+					actionDl.Stderr = os.Stderr
+					err := actionDl.Run()
+					if err == nil {
+						fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
+						fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
+					} else {
+						fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
+					}
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					os.Stdin.Read(make([]byte, 1))
+				}
+				gophertubeYouTubeMode(cmd)
+				return
+			}
+			
+			// New Audio playback logic
+			if choice == "Audio" {
+				player := checkAvailablePlayer()
+				if player == nil {
+					fmt.Println("    \033[1;31mNo media player found!\033[0m")
+					fmt.Println("    \033[0;37mPlease install MPV to play audio.\033[0m")
+					fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					os.Stdin.Read(make([]byte, 1))
+					continue // Go back to the search results
+				}
+				
+				fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
+				fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+				fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+				fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+				fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
+				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+				
+				// Extract direct audio stream URL
+				audioCmd := exec.Command("yt-dlp", "-f", "bestaudio[ext=m4a]/bestaudio", "-g", videos[selected].URL)
+				streamURLBytes, err := audioCmd.Output()
+				if err != nil {
+					fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
+					fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+					os.Stdin.Read(make([]byte, 1))
+					continue // Go back to the search results
+				}
+				streamURL := strings.TrimSpace(string(streamURLBytes))
+				
+				if err := playWithPlayer(player, streamURL, true); err != nil {
+					fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", player.Name)
+				}
+				
+				fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
+				os.Stdin.Read(make([]byte, 1))
+				continue // Return to the search results
+			}
+
+			// Watch as before
+			fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+			fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+			fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+			fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+			fmt.Println()
+			fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+			fmt.Println()
+			mpvPath := "mpv"
+			quality := cmd.String(FlagQuality)
+			var mpvArgs []string
+			if quality != "" {
+				// Map quality to ytdl-format string
+				var format string
+				switch quality {
+				case "1080p":
+					format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+				case "720p":
+					format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
+				case "480p":
+					format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
+				case "360p":
+					format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
+				case "Audio":
+					format = "bestaudio"
+					mpvArgs = append(mpvArgs, "--no-video")
+				default:
+					format = "best"
+				}
+				mpvArgs = append(mpvArgs, "--ytdl-format="+format)
+			}
+			mpvArgs = append(mpvArgs, videos[selected].URL)
+			exec.Command(mpvPath, mpvArgs...).Run()
+			continue
 		}
-		
-		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
-		
-		// Extract direct audio stream URL with better format selection
-		audioCmd := exec.Command("yt-dlp", "-f", "bestaudio[ext=m4a]/bestaudio", "-g", videos[selected].URL)
-		streamURLBytes, err := audioCmd.Output()
-		if err != nil {
-			fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
-			fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
-			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-			os.Stdin.Read(make([]byte, 1))
-			gophertubeYouTubeMode(cmd)
-			return
-		}
-		streamURL := strings.TrimSpace(string(streamURLBytes))
-		
-		// Play audio with detected terminal player
-		if err := playWithPlayer(audioPlayer, streamURL, true); err != nil {
-			fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", audioPlayer.Name)
-		}
-		
-		fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		gophertubeYouTubeMode(cmd)
-		return
-	}
-	
-	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
-	fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-	fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-	fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
-	
-	quality := cmd.String(FlagQuality)
-	isAudioOnly := quality == "Audio"
-	
-	// Extract direct streamable URL using yt-dlp with better format selection
-	var ytDlpCmd *exec.Cmd
-	if isAudioOnly {
-		ytDlpCmd = exec.Command("yt-dlp", "-f", "bestaudio", "-g", videos[selected].URL)
-	} else {
-		// Try to get the best video format that's compatible
-		ytDlpCmd = exec.Command("yt-dlp", "-f", "best[height<=1080]/best", "-g", videos[selected].URL)
-	}
-	
-	streamURLBytes, err := ytDlpCmd.Output()
-	if err != nil {
-		fmt.Println("    \033[1;31mFailed to get direct video URL.\033[0m")
-		fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
-		return
-	}
-	streamURL := strings.TrimSpace(string(streamURLBytes))
-	
-	// Play with detected player
-	if err := playWithPlayer(player, streamURL, isAudioOnly); err != nil {
-		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
 	}
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) {
 	files, err := os.ReadDir(cmd.String(FlagDownloadsPath))
 	if err != nil || len(files) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
-	
 	var videoFiles []string
 	for _, f := range files {
 		if !f.IsDir() && (strings.HasSuffix(f.Name(), ".mp4") || strings.HasSuffix(f.Name(), ".mkv") || strings.HasSuffix(f.Name(), ".webm") || strings.HasSuffix(f.Name(), ".avi")) {
 			videoFiles = append(videoFiles, f.Name())
 		}
 	}
-	
 	if len(videoFiles) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
-	
 	fzfPreview := fmt.Sprintf(`env file={} base="%s/${file%%.*}" thumb="$base.jpg" w=$((FZF_PREVIEW_COLUMNS * 9 / 10)) h=$((FZF_PREVIEW_LINES * 3 / 5)) sh -c '[ -f "$thumb" ] && chafa --size=${w}x${h} "$thumb" 2>/dev/null || echo "No image preview available" || echo "No thumbnail available"'`, cmd.String(FlagDownloadsPath))
 	action := exec.Command("fzf", "--prompt=Downloads: ", "--preview", fzfPreview)
 	action.Stdin = strings.NewReader(strings.Join(videoFiles, "\n"))
 	out, _ := action.Output()
 	selected := strings.TrimSpace(string(out))
-	
 	if selected == "" {
 		return
 	}
-	
-	// Check for available media player
-	player := checkAvailablePlayer()
-	if player == nil {
-		fmt.Println("    \033[1;31mNo media player found!\033[0m")
-		fmt.Println("    \033[0;37mPlease install MPV (recommended) or VLC to play videos.\033[0m")
-		fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		return
-	}
-	
 	filePath := cmd.String(FlagDownloadsPath) + "/" + selected
-	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), selected)
-	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
-	
-	// Play with detected player
-	if err := playWithPlayer(player, filePath, false); err != nil {
-		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
-	}
+	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
+	fmt.Println()
+	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+	fmt.Println()
+	mpvPath := "mpv"
+	exec.Command(mpvPath, filePath).Run()
 }

--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -106,7 +106,7 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
             }
 
             // Show Watch/Download/Audio menu
-            menu := []string{"Watch", "Download", "Audio"}
+            menu := []string{"Watch", "Download", "Listen"}
             action := exec.Command("fzf", "--prompt=Action: ")
             action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
             out, _ := action.Output()
@@ -170,7 +170,7 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
             }
 
             // New Audio playback logic
-            if choice == "Audio" {
+            if choice == "Listen" {
                 player := checkAvailablePlayer()
                 if player == nil {
                     fmt.Println("    \033[1;31mNo media player found!\033[0m")

--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -1,323 +1,289 @@
 package app
 
 import (
-	"fmt"
-	"gophertube/internal/services"
-	"os"
-	"os/exec"
-	"strings"
-	"time"
+    "fmt"
+    "gophertube/internal/services"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
 
-	"github.com/urfave/cli/v3"
+    "github.com/urfave/cli/v3"
 )
 
 // MediaPlayer represents available media players
 type MediaPlayer struct {
-	Name string
-	Path string
+    Name string
+    Path string
 }
 
 // checkAvailablePlayer checks for MPV.
 func checkAvailablePlayer() *MediaPlayer {
-	// Prefer MPV for better performance and terminal integration
-	if path, err := exec.LookPath("mpv"); err == nil {
-		return &MediaPlayer{
-			Name: "mpv",
-			Path: path,
-		}
-	}
-	return nil
+    // Prefer MPV for better performance and terminal integration
+    if path, err := exec.LookPath("mpv"); err == nil {
+        return &MediaPlayer{
+            Name: "mpv",
+            Path: path,
+        }
+    }
+    return nil
 }
 
 // playWithPlayer plays media using the detected player.
 func playWithPlayer(player *MediaPlayer, url string, isAudioOnly bool) error {
-	var args []string
+    var args []string
 
-	if isAudioOnly {
-		args = []string{"--no-video"}
-	}
+    if isAudioOnly {
+        args = []string{"--no-video"}
+    }
 
-	args = append(args, url)
+    args = append(args, url)
 
-	cmd := exec.Command(player.Path, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+    cmd := exec.Command(player.Path, args...)
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+    return cmd.Run()
 }
 
 func gophertubeYouTubeMode(cmd *cli.Command) {
-	query, esc := readQuery()
-	if esc || query == "" {
-		fmt.Print("\033[2J\033[H")
-		return
-	}
-	for {
-		// Spinner/progress state
-		progressCurrent := 0
-		progressTotal := 1
-		progressDone := make(chan struct{})
+    query, esc := readQuery()
+    if esc || query == "" {
+        fmt.Print("\033[2J\033[H")
+        return
+    }
+    for {
+        // Spinner/progress state
+        progressCurrent := 0
+        progressTotal := 1
+        progressDone := make(chan struct{})
 
-		// Start spinner goroutine
-		go func() {
-			for {
-				select {
-				case <-progressDone:
-					return
-				default:
-					printProgressBar(progressCurrent, progressTotal)
-					time.Sleep(100 * time.Millisecond)
-				}
-			}
-		}()
+        // Start spinner goroutine
+        go func() {
+            for {
+                select {
+                case <-progressDone:
+                    return
+                default:
+                    printProgressBar(progressCurrent, progressTotal)
+                    time.Sleep(100 * time.Millisecond)
+                }
+            }
+        }()
 
-		videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
-			progressCurrent = current
-			progressTotal = total
-		})
+        videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
+            progressCurrent = current
+            progressTotal = total
+        })
 
-		close(progressDone)
-		fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
-		fmt.Println()
-		fmt.Println()
+        close(progressDone)
+        fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
+        fmt.Println()
+        fmt.Println()
 
-		if err != nil || len(videos) == 0 {
-			fmt.Println("    \033[1;31mNo results found.\033[0m")
-			fmt.Println()
-			fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
-			os.Stdin.Read(make([]byte, 1))
-			return
-		}
+        if err != nil || len(videos) == 0 {
+            fmt.Println("    \033[1;31mNo results found.\033[0m")
+            fmt.Println()
+            fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
+            os.Stdin.Read(make([]byte, 1))
+            return
+        }
 
-		fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
-		printSearchStats(videos)
-		printSearchTips()
-		// Reduced delay for faster response
-		time.Sleep(200 * time.Millisecond)
+        fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
+        printSearchStats(videos)
+        printSearchTips()
+        // Reduced delay for faster response
+        time.Sleep(200 * time.Millisecond)
 
-		for {
-			selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
-			if selected == -2 {
-				// User pressed escape, go back to new search
-				return
-			}
-			if selected < 0 || selected >= len(videos) {
-				continue // Stay in the same list
-			}
+        for {
+            selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
+            if selected == -2 {
+                // User pressed escape, go back to new search
+                return
+            }
+            if selected < 0 || selected >= len(videos) {
+                continue // Stay in the same list
+            }
 
-<<<<<<< HEAD
-			// Show Watch/Download/Audio menu
-			menu := []string{"Watch", "Download", "Audio"}
-=======
-			// Show Watch/Download menu
-			menu := []string{"Watch", "Download"}
->>>>>>> upstream/main
-			action := exec.Command("fzf", "--prompt=Action: ")
-			action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
-			out, _ := action.Output()
-			choice := strings.TrimSpace(string(out))
-<<<<<<< HEAD
+            // Show Watch/Download/Audio menu
+            menu := []string{"Watch", "Download", "Audio"}
+            action := exec.Command("fzf", "--prompt=Action: ")
+            action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
+            out, _ := action.Output()
+            choice := strings.TrimSpace(string(out))
 
-=======
->>>>>>> upstream/main
-			if choice == "Download" {
-				qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
-				actionQ := exec.Command("fzf", "--prompt=Quality: ")
-				actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
-				outQ, _ := actionQ.Output()
-				selectedQ := strings.TrimSpace(string(outQ))
-				if selectedQ != "" {
-					// Real download logic
-					format := "best"
-					switch selectedQ {
-					case "1080p":
-						format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-					case "720p":
-						format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-					case "480p":
-						format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-					case "360p":
-						format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-					case "Audio":
-						format = "bestaudio"
-					}
-					os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
-					// Sanitize filename
-					filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
-					filename = strings.Map(func(r rune) rune {
-						if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
-							return r
-						}
-						return '_'
-					}, filename)
-					outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
-					fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
+            if choice == "Download" {
+                qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
+                actionQ := exec.Command("fzf", "--prompt=Quality: ")
+                actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
+                outQ, _ := actionQ.Output()
+                selectedQ := strings.TrimSpace(string(outQ))
+                if selectedQ != "" {
+                    // Real download logic
+                    format := "best"
+                    switch selectedQ {
+                    case "1080p":
+                        format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+                    case "720p":
+                        format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
+                    case "480p":
+                        format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
+                    case "360p":
+                        format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
+                    case "Audio":
+                        format = "bestaudio"
+                    }
+                    os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
+                    // Sanitize filename
+                    filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
+                    filename = strings.Map(func(r rune) rune {
+                        if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
+                            return r
+                        }
+                        return '_'
+                    }, filename)
+                    outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
+                    fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
 
-					ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+                    ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 
-					//override the default args with an audio only version.
-					// Note: this downlads it as a .webm, then converts it to a .opus file.
-					if format == "bestaudio" {
-						ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
-					}
-					actionDl := exec.Command("yt-dlp", ytDlpArgs...)
-					actionDl.Stdout = os.Stdout
-					actionDl.Stderr = os.Stderr
-					err := actionDl.Run()
-					if err == nil {
-						fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
-						fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
-					} else {
-						fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
-					}
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-					os.Stdin.Read(make([]byte, 1))
-				}
-				gophertubeYouTubeMode(cmd)
-				return
-			}
+                    //override the default args with an audio only version.
+                    // Note: this downlads it as a .webm, then converts it to a .opus file.
+                    if format == "bestaudio" {
+                        ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
+                    }
+                    actionDl := exec.Command("yt-dlp", ytDlpArgs...)
+                    actionDl.Stdout = os.Stdout
+                    actionDl.Stderr = os.Stderr
+                    err := actionDl.Run()
+                    if err == nil {
+                        fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
+                        fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
+                    } else {
+                        fmt.Printf("    \033[1;31mDownload failed!\033[0m\n")
+                    }
+                    fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+                    os.Stdin.Read(make([]byte, 1))
+                }
+                gophertubeYouTubeMode(cmd)
+                return
+            }
 
-<<<<<<< HEAD
-			// New Audio playback logic
-			if choice == "Audio" {
-				player := checkAvailablePlayer()
-				if player == nil {
-					fmt.Println("    \033[1;31mNo media player found!\033[0m")
-					fmt.Println("    \033[0;37mPlease install MPV to play audio.\033[0m")
-					fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-					os.Stdin.Read(make([]byte, 1))
-					continue // Go back to the search results
-				}
+            // New Audio playback logic
+            if choice == "Audio" {
+                player := checkAvailablePlayer()
+                if player == nil {
+                    fmt.Println("    \033[1;31mNo media player found!\033[0m")
+                    fmt.Println("    \033[0;37mPlease install MPV to play audio.\033[0m")
+                    fmt.Println("    \033[0;33mInstall MPV: sudo apt install mpv (Ubuntu) | brew install mpv (macOS)\033[0m")
+                    fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+                    os.Stdin.Read(make([]byte, 1))
+                    continue // Go back to the search results
+                }
 
-				fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
-				fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-				fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-				fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-				fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
-				fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+                fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
+                fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+                fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+                fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+                fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+                fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
+                fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
 
-				// Extract direct audio stream URL
-				audioCmd := exec.Command("yt-dlp", "-f", "bestaudio[ext=m4a]/bestaudio", "-g", videos[selected].URL)
-				streamURLBytes, err := audioCmd.Output()
-				if err != nil {
-					fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
-					fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
-					fmt.Println("    \033[0;37mPress any key to return...\033[0m")
-					os.Stdin.Read(make([]byte, 1))
-					continue // Go back to the search results
-				}
-				streamURL := strings.TrimSpace(string(streamURLBytes))
+                // Extract direct audio stream URL
+                audioCmd := exec.Command("yt-dlp", "-f", "bestaudio[ext=m4a]/bestaudio", "-g", videos[selected].URL)
+                streamURLBytes, err := audioCmd.Output()
+                if err != nil {
+                    fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
+                    fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+                    fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+                    os.Stdin.Read(make([]byte, 1))
+                    continue // Go back to the search results
+                }
+                streamURL := strings.TrimSpace(string(streamURLBytes))
 
-				if err := playWithPlayer(player, streamURL, true); err != nil {
-					fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", player.Name)
-				}
+                if err := playWithPlayer(player, streamURL, true); err != nil {
+                    fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", player.Name)
+                }
 
-				fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
-				os.Stdin.Read(make([]byte, 1))
-				continue // Return to the search results
-			}
+                fmt.Println("    \033[0;37mPress Enter to return.\033[0m")
+                os.Stdin.Read(make([]byte, 1))
+                continue // Return to the search results
+            }
 
-=======
->>>>>>> upstream/main
-			// Watch as before
-			fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
-			fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
-			fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
-			fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-			fmt.Println()
-			fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-			fmt.Println()
-			mpvPath := "mpv"
-			quality := cmd.String(FlagQuality)
-			var mpvArgs []string
-<<<<<<< HEAD
+            // Watch as before
+            fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+            fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+            fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+            fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+            fmt.Println()
+            fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+            fmt.Println()
+            mpvPath := "mpv"
+            quality := cmd.String(FlagQuality)
+            var mpvArgs []string
 
-			// Add the fullscreen flag for video playback
-			mpvArgs = append(mpvArgs, "--fs")
+            // Add the fullscreen flag for video playback
+            mpvArgs = append(mpvArgs, "--fs")
 
-			if quality != "" {
-				// Map quality to ytdl-format string
-				switch quality {
-				case "1080p":
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=1080]+bestaudio/best[height<=1080]")
-				case "720p":
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=720]+bestaudio/best[height<=720]")
-				case "480p":
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=480]+bestaudio/best[height<=480]")
-				case "360p":
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=360]+bestaudio/best[height<=360]")
-				case "Audio":
-					mpvArgs = append(mpvArgs, "--no-video")
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"bestaudio")
-				default:
-					mpvArgs = append(mpvArgs, "--ytdl-format="+"best")
-				}
-			}
+            if quality != "" {
+                // Map quality to ytdl-format string
+                switch quality {
+                case "1080p":
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=1080]+bestaudio/best[height<=1080]")
+                case "720p":
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=720]+bestaudio/best[height<=720]")
+                case "480p":
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=480]+bestaudio/best[height<=480]")
+                case "360p":
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"bestvideo[height<=360]+bestaudio/best[height<=360]")
+                case "Audio":
+                    mpvArgs = append(mpvArgs, "--no-video")
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"bestaudio")
+                default:
+                    mpvArgs = append(mpvArgs, "--ytdl-format="+"best")
+                }
+            }
 
-=======
-			if quality != "" {
-				// Map quality to ytdl-format string
-				var format string
-				switch quality {
-				case "1080p":
-					format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-				case "720p":
-					format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-				case "480p":
-					format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-				case "360p":
-					format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-				case "Audio":
-					format = "bestaudio"
-					mpvArgs = append(mpvArgs, "--no-video")
-				default:
-					format = "best"
-				}
-				mpvArgs = append(mpvArgs, "--ytdl-format="+format)
-			}
->>>>>>> upstream/main
-			mpvArgs = append(mpvArgs, videos[selected].URL)
-			exec.Command(mpvPath, mpvArgs...).Run()
-			continue
-		}
-	}
+            mpvArgs = append(mpvArgs, videos[selected].URL)
+            exec.Command(mpvPath, mpvArgs...).Run()
+            continue
+        }
+    }
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) {
-	files, err := os.ReadDir(cmd.String(FlagDownloadsPath))
-	if err != nil || len(files) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		return
-	}
-	var videoFiles []string
-	for _, f := range files {
-		if !f.IsDir() && (strings.HasSuffix(f.Name(), ".mp4") || strings.HasSuffix(f.Name(), ".mkv") || strings.HasSuffix(f.Name(), ".webm") || strings.HasSuffix(f.Name(), ".avi")) {
-			videoFiles = append(videoFiles, f.Name())
-		}
-	}
-	if len(videoFiles) == 0 {
-		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
-		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
-		os.Stdin.Read(make([]byte, 1))
-		return
-	}
-	fzfPreview := fmt.Sprintf(`env file={} base="%s/${file%%.*}" thumb="$base.jpg" w=$((FZF_PREVIEW_COLUMNS * 9 / 10)) h=$((FZF_PREVIEW_LINES * 3 / 5)) sh -c '[ -f "$thumb" ] && chafa --size=${w}x${h} "$thumb" 2>/dev/null || echo "No image preview available" || echo "No thumbnail available"'`, cmd.String(FlagDownloadsPath))
-	action := exec.Command("fzf", "--prompt=Downloads: ", "--preview", fzfPreview)
-	action.Stdin = strings.NewReader(strings.Join(videoFiles, "\n"))
-	out, _ := action.Output()
-	selected := strings.TrimSpace(string(out))
-	if selected == "" {
-		return
-	}
-	filePath := cmd.String(FlagDownloadsPath) + "/" + selected
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
-	exec.Command(mpvPath, filePath).Run()
+    files, err := os.ReadDir(cmd.String(FlagDownloadsPath))
+    if err != nil || len(files) == 0 {
+        fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+        fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+        os.Stdin.Read(make([]byte, 1))
+        return
+    }
+    var videoFiles []string
+    for _, f := range files {
+        if !f.IsDir() && (strings.HasSuffix(f.Name(), ".mp4") || strings.HasSuffix(f.Name(), ".mkv") || strings.HasSuffix(f.Name(), ".webm") || strings.HasSuffix(f.Name(), ".avi")) {
+            videoFiles = append(videoFiles, f.Name())
+        }
+    }
+    if len(videoFiles) == 0 {
+        fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
+        fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
+        os.Stdin.Read(make([]byte, 1))
+        return
+    }
+    fzfPreview := fmt.Sprintf(`env file={} base="%s/${file%%.*}" thumb="$base.jpg" w=$((FZF_PREVIEW_COLUMNS * 9 / 10)) h=$((FZF_PREVIEW_LINES * 3 / 5)) sh -c '[ -f "$thumb" ] && chafa --size=${w}x${h} "$thumb" 2>/dev/null || echo "No image preview available" || echo "No thumbnail available"'`, cmd.String(FlagDownloadsPath))
+    action := exec.Command("fzf", "--prompt=Downloads: ", "--preview", fzfPreview)
+    action.Stdin = strings.NewReader(strings.Join(videoFiles, "\n"))
+    out, _ := action.Output()
+    selected := strings.TrimSpace(string(out))
+    if selected == "" {
+        return
+    }
+    filePath := cmd.String(FlagDownloadsPath) + "/" + selected
+    fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
+    fmt.Println()
+    fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+    fmt.Println()
+    mpvPath := "mpv"
+    exec.Command(mpvPath, filePath).Run()
 }

--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -7,9 +7,92 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
 	"github.com/urfave/cli/v3"
 )
+
+// MediaPlayer represents available media players
+type MediaPlayer struct {
+	Name string
+	Path string
+	Type string // "video" or "audio"
+}
+
+// checkAvailablePlayer checks for VLC or MPV and returns the first available one
+func checkAvailablePlayer() *MediaPlayer {
+	players := []string{"mpv", "vlc"}
+	
+	for _, player := range players {
+		if path, err := exec.LookPath(player); err == nil {
+			return &MediaPlayer{
+				Name: player,
+				Path: path,
+				Type: "video",
+			}
+		}
+	}
+	return nil
+}
+
+// checkAvailableAudioPlayer checks for terminal-based audio players
+func checkAvailableAudioPlayer() *MediaPlayer {
+	// First check for mpv
+	if path, err := exec.LookPath("mpv"); err == nil {
+		return &MediaPlayer{
+			Name: "mpv",
+			Path: path,
+			Type: "audio",
+		}
+	}
+	
+	// Fallback to VLC if mpv not available
+	if path, err := exec.LookPath("vlc"); err == nil {
+		return &MediaPlayer{
+			Name: "vlc",
+			Path: path,
+			Type: "audio",
+		}
+	}
+	
+	return nil
+}
+
+// playWithPlayer plays media using the detected player
+func playWithPlayer(player *MediaPlayer, url string, isAudioOnly bool, isFullscreen bool) error {
+	var args []string
+	
+	switch player.Name {
+
+	case "mpv":
+		if player.Type == "audio" || isAudioOnly {
+			args = []string{"--no-video"}
+		} else {
+			args = []string{"--no-terminal"}
+			if isFullscreen {
+				args = append(args, "--fullscreen")
+ 			}
+		}
+		args = append(args, url)
+	
+			
+	case "vlc":
+		if player.Type == "audio" || isAudioOnly {
+			// VLC in audio-only mode
+			args = []string{"--play-and-exit", "--no-video", "--no-video-title-show"}
+		} else {
+			// VLC in video mode
+			args = []string{"--play-and-exit", "--no-video-title-show"}
+			if isFullscreen {
+				args = append(args, "--fullscreen")
+			}
+		}
+		args = append(args, url)
+	}
+	cmd := exec.Command(player.Path, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
 
 func gophertubeYouTubeMode(cmd *cli.Command) {
 	query, esc := readQuery()
@@ -17,13 +100,10 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		fmt.Print("\033[2J\033[H")
 		return
 	}
-
-	// Spinner/progress state
+	
 	progressCurrent := 0
 	progressTotal := 1
 	progressDone := make(chan struct{})
-
-	// Start spinner goroutine
 	go func() {
 		for {
 			select {
@@ -35,55 +115,46 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 			}
 		}
 	}()
-
+	
 	videos, err := services.SearchYouTube(query, cmd.Int(FlagSearchLimit), func(current, total int) {
 		progressCurrent = current
 		progressTotal = total
 	})
-
 	close(progressDone)
-	fmt.Print("\033[2K\r\n") // Clear progress bar/spinner line
-	fmt.Println()
-	fmt.Println()
-
+	fmt.Print("\033[2K\r\n")
+	fmt.Println("\n")
+	
 	if err != nil || len(videos) == 0 {
 		fmt.Println("    \033[1;31mNo results found.\033[0m")
-		fmt.Println()
-		fmt.Println("    \033[0;37mPress any key to search again...\033[0m")
+		fmt.Println("\n    \033[0;37mPress any key to search again...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
-
+	
 	fmt.Printf("    \033[1;32mFound %d results!\033[0m\n", len(videos))
 	printSearchStats(videos)
 	printSearchTips()
-	// Reduced delay for faster response
 	time.Sleep(200 * time.Millisecond)
-
+	
 	selected := runFzf(videos, cmd.Int(FlagSearchLimit), query)
-	if selected == -2 {
-		gophertubeYouTubeMode(cmd) // go back to search
-		return
-	}
-	if selected < 0 || selected >= len(videos) {
+	if selected == -2 || selected < 0 || selected >= len(videos) {
 		gophertubeYouTubeMode(cmd)
 		return
 	}
-
-	// Show Watch/Download menu
-	menu := []string{"Watch", "Download"}
+	
 	action := exec.Command("fzf", "--prompt=Action: ")
-	action.Stdin = strings.NewReader(strings.Join(menu, "\n"))
+	action.Stdin = strings.NewReader(strings.Join([]string{"Watch", "Download", "Audio"}, "\n"))
 	out, _ := action.Output()
 	choice := strings.TrimSpace(string(out))
+	
 	if choice == "Download" {
 		qualities := []string{"1080p", "720p", "480p", "360p", "Audio"}
 		actionQ := exec.Command("fzf", "--prompt=Quality: ")
 		actionQ.Stdin = strings.NewReader(strings.Join(qualities, "\n"))
 		outQ, _ := actionQ.Output()
 		selectedQ := strings.TrimSpace(string(outQ))
+		
 		if selectedQ != "" {
-			// Real download logic
 			format := "best"
 			switch selectedQ {
 			case "1080p":
@@ -97,8 +168,8 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 			case "Audio":
 				format = "bestaudio"
 			}
+			
 			os.MkdirAll(cmd.String(FlagDownloadsPath), 0755)
-			// Sanitize filename
 			filename := strings.ReplaceAll(videos[selected].Title, " ", "_")
 			filename = strings.Map(func(r rune) rune {
 				if strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", r) {
@@ -107,20 +178,17 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 				return '_'
 			}, filename)
 			outputPath := fmt.Sprintf("%s/%s.%%(ext)s", cmd.String(FlagDownloadsPath), filename)
+			
 			fmt.Printf("    \033[1;32mDownloading '%s' as %s...\033[0m\n", videos[selected].Title, selectedQ)
-
 			ytDlpArgs := []string{"-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
-
-			//override the default args with an audio only version.
-			// Note: this downlads it as a .webm, then converts it to a .opus file.
 			if format == "bestaudio" {
 				ytDlpArgs = []string{"-x", "-f", format, "-o", outputPath, "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", videos[selected].URL}
 			}
+			
 			actionDl := exec.Command("yt-dlp", ytDlpArgs...)
 			actionDl.Stdout = os.Stdout
 			actionDl.Stderr = os.Stderr
-			err := actionDl.Run()
-			if err == nil {
+			if err := actionDl.Run(); err == nil {
 				fmt.Printf("    \033[1;32mDownload complete!\033[0m\n")
 				fmt.Printf("    \033[0;37mSaved to: %s\033[0m\n", cmd.String(FlagDownloadsPath))
 			} else {
@@ -132,40 +200,94 @@ func gophertubeYouTubeMode(cmd *cli.Command) {
 		gophertubeYouTubeMode(cmd)
 		return
 	}
-
-	// Watch as before
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", videos[selected].Title)
+	
+	// Check for available media player
+	player := checkAvailablePlayer()
+	if player == nil {
+		fmt.Println("    \033[1;31mNo media player found!\033[0m")
+		fmt.Println("    \033[0;37mPlease install VLC or MPV to play videos.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		gophertubeYouTubeMode(cmd)
+		return
+	}
+	
+	// If user chooses to just play Audio
+	if choice == "Audio" {
+		// Check for available audio player (terminal-based preferred)
+		audioPlayer := checkAvailableAudioPlayer()
+		if audioPlayer == nil {
+			fmt.Println("    \033[1;31mNo audio player found!\033[0m")
+			fmt.Println("    \033[0;37mPlease install mpv, mplayer, or vlc to play audio.\033[0m")
+			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+			os.Stdin.Read(make([]byte, 1))
+			gophertubeYouTubeMode(cmd)
+			return
+		}
+		
+		fmt.Printf("    \033[1;33mPlaying Audio with %s: %s\033[0m\n", strings.ToUpper(audioPlayer.Name), videos[selected].Title)
+		fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
+		fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
+		fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
+		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
+		
+		// Show different controls based on player
+		switch audioPlayer.Name {
+		case "mpv":
+			fmt.Println("    \033[0;33mControls: 'q' to quit, SPACE to pause/resume, ←→ to seek\033[0m")
+		case "vlc":
+			fmt.Println("    \033[0;33mControls: Ctrl+C to quit, SPACE to pause/resume\033[0m")
+		}
+		
+		fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+		
+		// Extract direct audio stream URL
+		audioCmd := exec.Command("yt-dlp", "-f", "bestaudio", "-g", videos[selected].URL)
+		streamURLBytes, err := audioCmd.Output()
+		if err != nil {
+			fmt.Println("    \033[1;31mFailed to get direct audio URL.\033[0m")
+			fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+			fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+			os.Stdin.Read(make([]byte, 1))
+			gophertubeYouTubeMode(cmd)
+			return
+		}
+		streamURL := strings.TrimSpace(string(streamURLBytes))
+		
+		// Play audio with detected terminal player
+		if err := playWithPlayer(audioPlayer, streamURL, true, false); err != nil {
+			fmt.Printf("    \033[1;31mFailed to play audio with %s.\033[0m\n", audioPlayer.Name)
+		}
+		
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		gophertubeYouTubeMode(cmd)
+		return
+	}
+	
+	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), videos[selected].Title)
 	fmt.Printf("    \033[0;37mChannel: %s\033[0m\n", videos[selected].Author)
 	fmt.Printf("    \033[0;37mDuration: %s\033[0m\n", videos[selected].Duration)
 	fmt.Printf("    \033[0;36mPublished: %s\033[0m\n", videos[selected].Published)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
+	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+	
 	quality := cmd.String(FlagQuality)
-	var mpvArgs []string
-	if quality != "" {
-		// Map quality to ytdl-format string
-		var format string
-		switch quality {
-		case "1080p":
-			format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
-		case "720p":
-			format = "bestvideo[height<=720]+bestaudio/best[height<=720]"
-		case "480p":
-			format = "bestvideo[height<=480]+bestaudio/best[height<=480]"
-		case "360p":
-			format = "bestvideo[height<=360]+bestaudio/best[height<=360]"
-		case "Audio":
-			format = "bestaudio"
-			mpvArgs = append(mpvArgs, "--no-video")
-		default:
-			format = "best"
-		}
-		mpvArgs = append(mpvArgs, "--ytdl-format="+format)
+	isAudioOnly := quality == "Audio"
+	
+	// Extract direct streamable URL using yt-dlp
+	ytDlpCmd := exec.Command("yt-dlp", "-f", "best", "-g", videos[selected].URL)
+	streamURLBytes, err := ytDlpCmd.Output()
+	if err != nil {
+		fmt.Println("    \033[1;31mFailed to get direct video URL.\033[0m")
+		fmt.Println("    \033[0;37mMake sure yt-dlp is installed.\033[0m")
+		return
 	}
-	mpvArgs = append(mpvArgs, videos[selected].URL)
-	exec.Command(mpvPath, mpvArgs...).Run()
+	streamURL := strings.TrimSpace(string(streamURLBytes))
+	
+	// Play with detected player
+	if err := playWithPlayer(player, streamURL, isAudioOnly, true); err != nil {
+		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
+	}
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) {
@@ -176,31 +298,47 @@ func gophertubeDownloadsMode(cmd *cli.Command) {
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
+	
 	var videoFiles []string
 	for _, f := range files {
 		if !f.IsDir() && (strings.HasSuffix(f.Name(), ".mp4") || strings.HasSuffix(f.Name(), ".mkv") || strings.HasSuffix(f.Name(), ".webm") || strings.HasSuffix(f.Name(), ".avi")) {
 			videoFiles = append(videoFiles, f.Name())
 		}
 	}
+	
 	if len(videoFiles) == 0 {
 		fmt.Println("    \033[1;31mNo downloaded videos found.\033[0m")
 		fmt.Println("    \033[0;37mPress any key to return to main menu...\033[0m")
 		os.Stdin.Read(make([]byte, 1))
 		return
 	}
+	
 	fzfPreview := fmt.Sprintf(`env file={} base="%s/${file%%.*}" thumb="$base.jpg" w=$((FZF_PREVIEW_COLUMNS * 9 / 10)) h=$((FZF_PREVIEW_LINES * 3 / 5)) sh -c '[ -f "$thumb" ] && chafa --size=${w}x${h} "$thumb" 2>/dev/null || echo "No image preview available" || echo "No thumbnail available"'`, cmd.String(FlagDownloadsPath))
 	action := exec.Command("fzf", "--prompt=Downloads: ", "--preview", fzfPreview)
 	action.Stdin = strings.NewReader(strings.Join(videoFiles, "\n"))
 	out, _ := action.Output()
 	selected := strings.TrimSpace(string(out))
+	
 	if selected == "" {
 		return
 	}
+	
+	// Check for available media player
+	player := checkAvailablePlayer()
+	if player == nil {
+		fmt.Println("    \033[1;31mNo media player found!\033[0m")
+		fmt.Println("    \033[0;37mPlease install VLC or MPV to play videos.\033[0m")
+		fmt.Println("    \033[0;37mPress any key to return...\033[0m")
+		os.Stdin.Read(make([]byte, 1))
+		return
+	}
+	
 	filePath := cmd.String(FlagDownloadsPath) + "/" + selected
-	fmt.Printf("    \033[1;33mPlaying: %s\033[0m\n", selected)
-	fmt.Println()
-	fmt.Println("    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m")
-	fmt.Println()
-	mpvPath := "mpv"
-	exec.Command(mpvPath, filePath).Run()
+	fmt.Printf("    \033[1;33mPlaying with %s: %s\033[0m\n", strings.ToUpper(player.Name), selected)
+	fmt.Println("\n    \033[1;35m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n")
+	
+	// Play with detected player
+	if err := playWithPlayer(player, filePath, false, false); err != nil {
+		fmt.Printf("    \033[1;31mFailed to play video with %s.\033[0m\n", player.Name)
+	}
 }


### PR DESCRIPTION
I previously requested this feature, but I have now removed all VLC fallback options since the project already includes mpv as a dependency.

The app can now play both audio and video, and it continues to support downloading as before.

VLC is no longer required, and everything works smoothly using mpv.

