### PR TITLE
feat: add configurable fullscreen flag for mpv playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ search_limit = 30
 quality = "1080p"           # default: 1080p (options: 1080p, 720p, 480p, 360p, Audio)
 downloads_path = "/home/$USER/Videos/GopherTube"  # where to save downloads
 theme = "Minimal"                                 # default: Minimal (options: Minimal, Gopher, Gruvbox, etc)
+fullscreen = true                                 # default: true; set to false for windowed mpv (tiling WMs)
 ```
 
 ### Configuration Options
@@ -139,6 +140,7 @@ theme = "Minimal"                                 # default: Minimal (options: M
 | quality          | string | "1080p"                                   | Preferred quality or `Audio` for audio-only. |
 | downloads_path   | string | "$HOME/Videos/GopherTube"                | Directory to save downloads.                 |
 | theme            | string | "Minimal"                                 | Default application theme.                   |
+| fullscreen       | bool   | true                                      | Start mpv in fullscreen for video playback. Set to `false` for tiling WMs. |
 
 ---
 

--- a/config/gophertube.toml
+++ b/config/gophertube.toml
@@ -10,3 +10,6 @@ quality = "1080p"
 downloads_path = "/home/$USER/Videos/GopherTube" 
 # Default theme (e.g. Minimal, Gopher, Gruvbox)
 theme = "Minimal"
+# Start mpv in fullscreen for video playback (default: true).
+# Set to false to play in a windowed mpv (e.g. when using a tiling window manager).
+fullscreen = true

--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -18,6 +18,7 @@ const (
 	FlagConfig        = "config"
 	FlagDownloadsPath = "downloads-path"
 	FlagTheme         = "theme"
+	FlagFullscreen    = "fullscreen"
 
 	defaultConfigPath    = "$HOME/.config/gophertube/gophertube.toml"
 	defaultDownloadsPath = "$HOME/Videos/GopherTube"
@@ -75,6 +76,13 @@ func Flags() []cli.Flag {
 			),
 			Value: "Minimal",
 		},
+		&cli.BoolFlag{
+			Name: FlagFullscreen,
+			Sources: cli.NewValueSourceChain(
+				toml.TOML("fullscreen", altsrc.NewStringPtrSourcer(&confDir)),
+			),
+			Value: true,
+		},
 	}
 }
 
@@ -102,6 +110,7 @@ type GopherTubeConfig struct {
 	Quality       string `toml:"quality"`
 	DownloadsPath string `toml:"downloads_path"`
 	Theme         string `toml:"theme"`
+	Fullscreen    bool   `toml:"fullscreen"`
 }
 
 func SaveConfig(cmd *cli.Command) error {
@@ -115,6 +124,7 @@ func SaveConfig(cmd *cli.Command) error {
 		Quality:       cmd.String(FlagQuality),
 		DownloadsPath: cmd.String(FlagDownloadsPath),
 		Theme:         CurrentThemeName(),
+		Fullscreen:    cmd.Bool(FlagFullscreen),
 	}
 
 	f, err := os.Create(confPath)

--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -218,8 +218,10 @@ func gophertubeYouTubeMode(cmd *cli.Command) bool {
 		quality := cmd.String(FlagQuality)
 		var mpvArgs []string
 
-		// Add the fullscreen flag for video playback
-		mpvArgs = append(mpvArgs, "--fs", "--input-terminal=yes", "--no-terminal", "--msg-level=all=no")
+		if cmd.Bool(FlagFullscreen) {
+			mpvArgs = append(mpvArgs, "--fs")
+		}
+		mpvArgs = append(mpvArgs, "--input-terminal=yes", "--no-terminal", "--msg-level=all=no")
 
 		if quality != "" {
 			f := qualityToFormat(quality)
@@ -242,6 +244,7 @@ func gophertubeYouTubeMode(cmd *cli.Command) bool {
 }
 
 func gophertubeDownloadsMode(cmd *cli.Command) bool {
+	fullscreen := cmd.Bool(FlagFullscreen)
 	dlPath := expandPath(cmd.String(FlagDownloadsPath))
 	for {
 		files, err := os.ReadDir(dlPath)
@@ -269,7 +272,11 @@ func gophertubeDownloadsMode(cmd *cli.Command) bool {
 			return false
 		}
 		filePath := filepath.Join(dlPath, selected)
-		mpvArgs := []string{"--fs", "--input-terminal=yes", "--no-terminal", "--msg-level=all=no", filePath}
+		var mpvArgs []string
+		if fullscreen {
+			mpvArgs = append(mpvArgs, "--fs")
+		}
+		mpvArgs = append(mpvArgs, "--input-terminal=yes", "--no-terminal", "--msg-level=all=no", filePath)
 		exit, back, _ = runPlaybackTea(selected, "", "", "", "Playing: ", mpvArgs)
 		if exit {
 			return true


### PR DESCRIPTION
Introduce a new `fullscreen` option (CLI flag and TOML config key) that controls whether mpv is launched with `--fs` for video playback. Default remains `true` to preserve existing behavior; setting it to `false` keeps mpv windowed, which is useful for tiling window manager setups.

Changes:
- internal/app/flags.go: register `FlagFullscreen` BoolFlag, persist via TOML, and extend GopherTubeConfig with a `Fullscreen` field.
- internal/app/modes.go: conditionally append `--fs` to mpv args in both the YouTube playback and downloads playback flows.
- config/gophertube.toml: document the new `fullscreen` key with a default example.
- README.md: add the option to the example config and the options table.