### PR TITLE
[codex] upload Go module dependency archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
       - name: download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: final
           merge-multiple: true
+      - name: build Go module dependency archive
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          GOMODCACHE="${PWD}/go-mod" go mod download -modcacherw
+          XZ_OPT="-T0 -9" tar -acf "final/gophertube-${VERSION}-deps.tar.xz" go-mod
       - name: Generate SHA256 checksums
         run: |
           cd final


### PR DESCRIPTION
## Summary

- add checkout/setup-go to the release job
- build `gophertube-${VERSION}-deps.tar.xz` from `go mod download -modcacherw`
- include the dependency archive in the existing release checksum generation and upload

## Why

Gentoo's current Go eclass support works best with a release-attached module cache archive instead of an overlay-maintained `EGO_SUM` list. Publishing this archive from CI makes downstream packaging reproducible without committing `vendor/` to the repository.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
- locally ran the archive command with `GITHUB_REF_NAME=v2.8.2`; it produced `final/gophertube-2.8.2-deps.tar.xz`
