### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ fullscreen = true                                 # default: true; set to false 
 
 ## Star History
 
-<a href="https://www.star-history.com/#KrishnaSSH/GopherTube&Timeline">
+<a href="https://star-history.dera.page/#KrishnaSSH/GopherTube&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=KrishnaSSH/GopherTube&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=KrishnaSSH/GopherTube&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=KrishnaSSH/GopherTube&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=KrishnaSSH/GopherTube&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=KrishnaSSH/GopherTube&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=KrishnaSSH/GopherTube&type=Timeline" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the old provider can no longer reliably fetch stargazer data from the GitHub API. This change points the chart to star-history.dera.page, a working alternative that uses a different data source requiring no API token.

The wrapping link, the SVG endpoints, and the dark/light theme variants have all been updated to the new domain.